### PR TITLE
Improve traffic shaping to reduce packet loss and video stuttering

### DIFF
--- a/libftl/ftl_private.h
+++ b/libftl/ftl_private.h
@@ -67,7 +67,7 @@
 #define RTP_FUA_HEADER_LEN 2
 #define NACK_RB_SIZE (2048) //must be evenly divisible by 2^16
 #define NACK_RTT_AVG_SECONDS 5
-#define MAX_STATUS_MESSAGE_QUEUED 10
+#define MAX_STATUS_MESSAGE_QUEUED 100
 #define MAX_FRAME_SIZE_ELEMENTS 64 //must be a minimum of 3
 #define MAX_XMIT_LEVEL_IN_MS 100 //allows a maximum burst size of 100ms at the target bitrate
 #define VIDEO_RTP_TS_CLOCK_HZ 90000

--- a/libftl/ftl_private.h
+++ b/libftl/ftl_private.h
@@ -69,7 +69,7 @@
 #define NACK_RTT_AVG_SECONDS 5
 #define MAX_STATUS_MESSAGE_QUEUED 100
 #define MAX_FRAME_SIZE_ELEMENTS 64 //must be a minimum of 3
-#define MAX_XMIT_LEVEL_IN_MS 100 //allows a maximum burst size of 100ms at the target bitrate
+#define MAX_XMIT_LEVEL_IN_MS 5 // allows a maximum burst size of 5ms at the peak bitrate
 #define VIDEO_RTP_TS_CLOCK_HZ 90000
 #define AUDIO_SAMPLE_RATE 48000
 #define AUDIO_PACKET_DURATION_MS 20

--- a/libftl/ftl_private.h
+++ b/libftl/ftl_private.h
@@ -61,11 +61,11 @@
 #define KEEPALIVE_SEND_WARN_TOLERANCE_MS 1000
 #define STATUS_THREAD_SLEEP_TIME_MS 500
 #define MAX_PACKET_BUFFER 1500  //Max length of buffer
-#define MAX_MTU 1392
+#define MAX_MTU 1200 // Maximum allowed MTU value
 #define FTL_UDP_MEDIA_PORT 8082   //legacy port
 #define RTP_HEADER_BASE_LEN 12
 #define RTP_FUA_HEADER_LEN 2
-#define NACK_RB_SIZE (2048) //must be evenly divisible by 2^16
+#define NACK_RB_SIZE (4096) // must evenly divide 2^16
 #define NACK_RTT_AVG_SECONDS 5
 #define MAX_STATUS_MESSAGE_QUEUED 100
 #define MAX_FRAME_SIZE_ELEMENTS 64 //must be a minimum of 3
@@ -300,7 +300,7 @@ typedef struct {
   OS_THREAD_HANDLE audio_send_thread;
   OS_THREAD_HANDLE ping_thread;
   OS_SEMAPHORE ping_thread_shutdown;
-  int max_mtu;
+  int mtu;
   struct timeval stats_tv;
   int last_rtt_delay;
   struct timeval sender_report_base_ntp;

--- a/libftl/media.c
+++ b/libftl/media.c
@@ -390,7 +390,7 @@ void _update_timestamp(ftl_stream_configuration_private_t *ftl, ftl_media_compon
     ftl->media.sender_report_base_ntp.tv_usec == 0)
   {
     gettimeofday(&ftl->media.sender_report_base_ntp, NULL);
-    FTL_LOG(ftl, FTL_LOG_INFO, "Sender report base ntp time set to %llu us\n", mc->payload_type, timeval_to_us(&ftl->media.sender_report_base_ntp));
+    FTL_LOG(ftl, FTL_LOG_INFO, "Sender report base ntp time set to %llu us\n", timeval_to_us(&ftl->media.sender_report_base_ntp));
   }
 
   if (mc->base_dts_usec < 0) {

--- a/libftl/media.c
+++ b/libftl/media.c
@@ -117,7 +117,7 @@ ftl_status_t media_init(ftl_stream_configuration_private_t *ftl) {
             return status;
     }
 
-    media->max_mtu = MAX_MTU;
+    media->mtu = MAX_MTU;
     gettimeofday(&media->stats_tv, NULL);
     media->sender_report_base_ntp.tv_usec = 0;
     media->sender_report_base_ntp.tv_sec = 0;
@@ -282,7 +282,7 @@ ftl_status_t _internal_media_destroy(ftl_stream_configuration_private_t *ftl) {
   ftl_media_component_common_t *audio_comp = &ftl->audio.media_component;
   _nack_destroy(audio_comp);
 
-  media->max_mtu = 0;
+  media->mtu = 0;
   os_delete_mutex(&media->mutex);
   os_delete_mutex(&ftl->audio.mutex);
   os_delete_mutex(&ftl->video.mutex);
@@ -975,7 +975,7 @@ static int _media_make_video_rtp_packet(ftl_stream_configuration_private_t *ftl,
   mc->seq_num++;
 
   //if this packet can fit into a it's own packet then just use single nalu mode
-  if (first_pkt && in_len <= (ftl->media.max_mtu - RTP_HEADER_BASE_LEN)) {
+  if (first_pkt && in_len <= (ftl->media.mtu - RTP_HEADER_BASE_LEN)) {
     frag_len = in_len;
     *out_len = frag_len + rtp_hdr_len;
     memcpy(out, in, frag_len);
@@ -988,7 +988,7 @@ static int _media_make_video_rtp_packet(ftl_stream_configuration_private_t *ftl,
       in += 1;
       in_len--;
     }
-    else if (in_len <= (ftl->media.max_mtu - RTP_HEADER_BASE_LEN - RTP_FUA_HEADER_LEN)) {
+    else if (in_len <= (ftl->media.mtu - RTP_HEADER_BASE_LEN - RTP_FUA_HEADER_LEN)) {
       ebit = 1;
     }
 
@@ -997,7 +997,7 @@ static int _media_make_video_rtp_packet(ftl_stream_configuration_private_t *ftl,
 
     out += 2;
 
-    frag_len = ftl->media.max_mtu - rtp_hdr_len - RTP_FUA_HEADER_LEN;
+    frag_len = ftl->media.mtu - rtp_hdr_len - RTP_FUA_HEADER_LEN;
 
     if (frag_len > in_len) {
       frag_len = in_len;

--- a/libftl/media.c
+++ b/libftl/media.c
@@ -1223,11 +1223,11 @@ OS_THREAD_ROUTINE video_send_thread(void *data)
   while (1) {
 
     if (initial_peak_kbps != video->peak_kbps) {
+      bytes_per_ms = video->peak_kbps * 1000 / 8 / 1000;
       initial_peak_kbps = video->kbps = video->peak_kbps;
     }
 
     if (video->kbps != video_kbps) {
-      bytes_per_ms = video->kbps * 1000 / 8 / 1000;
       video_kbps = video->kbps;
 
       disable_flow_control = 0;


### PR DESCRIPTION
This distills the changes I've been testing that improve how outgoing video packets are paced and also brings in some tweaked values from the battle-tested WebRTC project. This does not fix the root cause of video stuttering, see https://github.com/Glimesh/janus-ftl-plugin/issues/101 for more details on that issue.

Changes:
1. Increase the limit on video send bitrate to the application-controller `peak_kbps` value as was originally intended in this code
1. Decrease the send token bucket size to align with WebRTC
1. Decrease the maximum transmission unit to align with WebRTC

The original goal of this change was to solve issues where some users reported 'stuttering' on streams where on every keyframe the stream would pause for a fraction of a second before skipping forward. In extreme cases the stutter can last for more than a second or video can drop out entirely.

I've since investigated further and confirmed the actual root cause of stutters is due to the behavior of the WebRTC stack on the client side, see https://github.com/Glimesh/janus-ftl-plugin/issues/101 for details. I'd still like to come back to this change once that issue is addressed, I still think we can make some small changes here that reduce packet loss for some users with bad networks while also reducing latency for users with good networks.

See the individual commits for additional detail but as an overview, this centers on how FTL uses a [token bucket](https://en.wikipedia.org/wiki/Token_bucket) to shape outgoing video packets. They call this the `transmit_level`. It fills at a rate of `bytes_per_ms` which is currently based on `video->kbps` currently and the bucket holds up to `bytes_per_ms * 100ms`. In practice this means for a 5000kbps target video bitrate you can send up to 62.5KB in a 100ms period before the video send thread will start sleeping to smooth out traffic.

The main issue with this is that keyframes can be much larger than 62.5KB depending on your encoder settings and type of content you are streaming. I've observed keyframes of up to 250KB at a 5000kbps bitrate which based on the current smoothing will take 320ms to fully send the keyframe. That is a huge jump in latency for a streaming protocol like FTL that aims for sub-second latency.

In theory this should just show up as significant delay as buffering is done on the viewer side to handle this large packet delivery jitter. However we've seen specially on mostly static streams that only have one small part changing (such as a countdown timer) that the video will pause or "stutter" a very noticeable amount on nearly every keyframe. I've confirmed what is happening is the user's WebRTC stack is not expanding the jitter buffer enough to handle the keyframe delay, see https://github.com/Glimesh/janus-ftl-plugin/issues/101 for details.

As a final note, this codebase is honestly not of the best quality and OBS I think is right to try and drop support for it as soon as an alternative low-latency protocol exists. In my view the best longer-term option remains getting WebRTC or other modern low-latency protocol supported in OBS.